### PR TITLE
fix: Use type keyword for type imports

### DIFF
--- a/multi-step-flow/src/app/extensions/components/MenuPanelContent.tsx
+++ b/multi-step-flow/src/app/extensions/components/MenuPanelContent.tsx
@@ -11,7 +11,7 @@ import {
   TableBody,
   ToggleGroup,
 } from '@hubspot/ui-extensions';
-import { MenuItem, type MenuPanelContentProps } from '../types';
+import type { MenuItem, MenuPanelContentProps } from '../types';
 import { MenuItemRow } from './MenuItemRow';
 
 export const MenuPanelContent = ({

--- a/multi-step-flow/src/app/extensions/components/RestaurantsTable.tsx
+++ b/multi-step-flow/src/app/extensions/components/RestaurantsTable.tsx
@@ -1,10 +1,10 @@
 import React, { useState } from 'react';
 import { Panel, Table, TableBody, Text } from '@hubspot/ui-extensions';
 import { RestaurantRow } from './RestaurantRow';
-import {
+import type {
   ButtonOnClickReactons,
   Restaurant,
-  type RestaurantsTableProps,
+  RestaurantsTableProps,
 } from '../types';
 import { MenuPanelContent } from './MenuPanelContent';
 


### PR DESCRIPTION
## Before 
<img width="921" alt="image" src="https://github.com/HubSpot/uie-beta-public-app-samples/assets/134086585/2f3b1ab7-f9bc-4a2e-9998-bf8d2f330144">

## After
<img width="838" alt="image" src="https://github.com/HubSpot/uie-beta-public-app-samples/assets/134086585/6cdabfd8-0baa-42dc-b580-80460cc2166f">
